### PR TITLE
FEM-2500 KAVA fired "playbackType = live" when DVR mode enabled

### DIFF
--- a/PlayKitKava.podspec
+++ b/PlayKitKava.podspec
@@ -5,7 +5,7 @@ suffix = '-dev'   # Dev mode
 Pod::Spec.new do |s|
     
     s.name                    = 'PlayKitKava'
-    s.version                 = '1.1.0' + suffix
+    s.version                 = '1.2.0' + suffix
     s.summary                 = 'PlayKitKava -- Analytics framework for iOS'
     s.homepage                = 'https://github.com/kaltura/playkit-ios-kava'
     s.license                 = { :type => 'AGPLv3', :file => 'LICENSE' }

--- a/Sources/KavaHelper.swift
+++ b/Sources/KavaHelper.swift
@@ -182,9 +182,7 @@ class KavaHelper {
                                    request: KalturaRequestBuilder) {
         if let duration = kavaData.mediaDuration,
             let currentTime = kavaData.mediaCurrentTime {
-            if KavaPluginData.hasDVR(duration: duration,
-                                     currentTime: currentTime,
-                                     dvrThreshold: config.dvrThreshold) {
+            if KavaPluginData.inDVRState(duration: duration, currentTime: currentTime, dvrThreshold: config.dvrThreshold) {
                 request.setParam(key: "playbackType", value: "dvr")
             } else {
                 request.setParam(key: "playbackType", value: "live")

--- a/Sources/KavaPlugin.swift
+++ b/Sources/KavaPlugin.swift
@@ -256,16 +256,7 @@ let playbackPoints: [KavaPlugin.KavaEventType] = [KavaPlugin.KavaEventType.playR
         }
         
         self.kavaData.mediaDuration = player.duration
-        
-        // Handle media current time. For live, send position against real time in "-" (minus values)
-        let mediaCurrentTime: TimeInterval
-        if player.isLive() {
-            let currentTime = player.currentTime - player.duration
-            mediaCurrentTime = currentTime <= 0 ? currentTime : 0
-        } else {
-            mediaCurrentTime = player.currentTime
-        }
-        self.kavaData.mediaCurrentTime = mediaCurrentTime
+        self.kavaData.mediaCurrentTime = player.currentTime
         
         guard let builder: KalturaRequestBuilder = KavaHelper.builder(config: self.config, 
                                                                       mediaType: declaredMediaType,

--- a/Sources/KavaPluginData.swift
+++ b/Sources/KavaPluginData.swift
@@ -68,11 +68,8 @@ class KavaPluginData {
 }
 
 extension KavaPluginData {
-    static func hasDVR(duration: Double,
-                       currentTime: Double,
-                       dvrThreshold: Int) -> Bool {
+    static func inDVRState(duration: Double, currentTime: Double, dvrThreshold: Int) -> Bool {
         let distanceFromLive = duration - currentTime
-        
         return distanceFromLive >= Double(dvrThreshold)
     }
 }


### PR DESCRIPTION
Fixed value of playbackType for Live media.
The logic was not relevant any more for the player's current time.