### PR TITLE
FEM-2280 Kava - Events should be sent out as GET

### DIFF
--- a/Sources/KavaPlugin.swift
+++ b/Sources/KavaPlugin.swift
@@ -269,6 +269,7 @@ let playbackPoints: [KavaPlugin.KavaEventType] = [KavaPlugin.KavaEventType.playR
                 return
         }
         
+        builder.set(method: .get)
         builder.add(headerKey: "User-Agent", headerValue: KavaPlugin.userAgent)
         builder.set { (response: Response) in
             PKLog.debug("Response: \(String(describing: response))")


### PR DESCRIPTION
### Description of the Changes

Set the request method, for the kava events, to GET instead of POST.
The default value of the 'KalturaRequestBuilder' is set to POST.