### PR TITLE
FEM-2789 Removed AdEvent.error sent to the kava error event.

### DIFF
--- a/PlayKitKava.podspec
+++ b/PlayKitKava.podspec
@@ -18,8 +18,7 @@ Pod::Spec.new do |s|
 
     s.source_files            = 'Sources/*'
 
-    s.dependency 'PlayKit/Core', '~> 3.16'
-    s.dependency 'PlayKit/AnalyticsCommon'
+    s.dependency 'PlayKit/AnalyticsCommon', '~> 3.16' + suffix
 end
 
 # To add playkit kava as dependecy use: s.dependency 'PlayKitKava', 'version_number'

--- a/Sources/KavaPlugin+AnalyticsPluginProtocol.swift
+++ b/Sources/KavaPlugin+AnalyticsPluginProtocol.swift
@@ -79,16 +79,10 @@ extension KavaPlugin: AnalyticsPluginProtocol {
                 assertionFailure("all player events must be handled")
             }
         })
-        
-        self.messageBus?.addObserver(self, events: [AdEvent.error], block: { [weak self] (event) in
-            guard let self = self else { return }
-            self.handleError(error: event.error)
-        })
     }
     
     public func unregisterEvents() {
         self.messageBus?.removeObserver(self, events: playerEventsToRegister)
-        self.messageBus?.removeObserver(self, events: [AdEvent.error])
     }
     
     /************************************************************/


### PR DESCRIPTION

### Description of the Changes

Removed AdEvent.error sent to the kava error event.
In the podspec, removed the PlayKit/Core dependency because it is embedded in PlayKit/AnalyticsCommon.