### PR TITLE
FEC-10101 The entryId sent in the config is not used.

### DIFF
--- a/Sources/KavaHelper.swift
+++ b/Sources/KavaHelper.swift
@@ -77,7 +77,9 @@ class KavaHelper {
         }
         request.setParam(key: "sessionId", value: player.sessionId)
         
-        if let entryId = player.mediaEntry?.id {
+        if let configEntryId = config.entryId {
+            request.setParam(key: "entryId", value: configEntryId)
+        } else if let entryId = player.mediaEntry?.id {
             request.setParam(key: "entryId", value: entryId)
         }
         


### PR DESCRIPTION
### Description of the Changes

Using the config entryId if available otherwise the mediaEntry id is used.