### PR TITLE
FEC-10474 Rename class 'USRExecutor' to 'KNKRequestExecutor'

### DIFF
--- a/PlayKitKava.podspec
+++ b/PlayKitKava.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
     s.source_files            = 'Sources/*'
 
-    s.dependency 'PlayKit/AnalyticsCommon', '~> 3.16'
+    s.dependency 'PlayKit/AnalyticsCommon', '~> 3.18'
 end
 
 # To add playkit kava as dependecy use: s.dependency 'PlayKitKava', 'version_number'

--- a/Sources/KavaPlugin.swift
+++ b/Sources/KavaPlugin.swift
@@ -351,7 +351,7 @@ let playbackPoints: [KavaPlugin.EventType] = [KavaPlugin.EventType.playReached25
         }
         
         PKLog.debug("Sending Kava Event, \(event) (\(event.rawValue)): \(builder.urlParams!)")
-        USRExecutor.shared.send(request: builder.build())
+        KNKRequestExecutor.shared.send(request: builder.build())
         
         self.eventIndex += 1
         self.kavaData.totalBufferingInCurrentInterval = TimeInterval()


### PR DESCRIPTION
### Description of the Changes

* Updated renamed class in KalturaNetKit, from USRExecutor to KNKRequestExecutor.
* Updated dependency of PlayKit to 3.18, for KalturaNetKit.

Solves FEC-10474 & FEC-10431