### PR TITLE
FEC-11234 Default Kava Impression & PLAY_REQUEST Events

### DIFF
--- a/Sources/KavaHelper.swift
+++ b/Sources/KavaHelper.swift
@@ -79,8 +79,9 @@ class KavaHelper {
         
         if let configEntryId = config.entryId {
             request.setParam(key: "entryId", value: configEntryId)
-        } else if let entryId = player.mediaEntry?.id {
-            request.setParam(key: "entryId", value: entryId)
+        } else {
+            request.setParam(key: "partnerId", value: String(KavaPluginConfig.defaultKavaPartnerId))
+            request.setParam(key: "entryId", value: KavaPluginConfig.defaultKavaEntryId)
         }
         
         if let sessionStartTime = config.sessionStartTime {

--- a/Sources/KavaPluginConfig.swift
+++ b/Sources/KavaPluginConfig.swift
@@ -32,6 +32,8 @@ import PlayKit
     /************************************************************/
     
     private let defaultBaseUrl = "https://analytics.kaltura.com/api_v3/index.php"
+    static let defaultKavaPartnerId: Int = 2504201
+    static let defaultKavaEntryId: String = "1_3bwzbc9o"
     
     /// application ID.
     let applicationId = Bundle.main.bundleIdentifier


### PR DESCRIPTION
Solves FEC-11234

In case, where Kava is there but the config is incorrect or the mediaEntry does not belong to Kaltura. From the KavaPlugin itself need to send DEFAULT partnerId and entryId instead of ignoring all the events, we will fire PLAY_REQUEST once for that media.