### PR TITLE
FEC-11651 - send OVP entryId if available on the metadata object 

### DIFF
--- a/Sources/KavaPlugin.swift
+++ b/Sources/KavaPlugin.swift
@@ -326,22 +326,22 @@ let playbackPoints: [KavaPlugin.EventType] = [KavaPlugin.EventType.playReached25
         self.kavaData.mediaCurrentTime = player.currentTime
         
         if let metadata = player.mediaEntry?.metadata,
-             let partnerId = Int(metadata["partnerId"] ?? "") {
+           let partnerId = Int(metadata["partnerId"] ?? "") {
             config.partnerId = partnerId
         }
         
         if config.entryId == nil,
-                  let metadata = player.mediaEntry?.metadata,
-                  let entryId = metadata["entryId"] {
+           let metadata = player.mediaEntry?.metadata,
+           let entryId = metadata["entryId"] {
             
             updateEntryId(entryId)
-                  
+            
         } else if config.entryId == nil,
-           let entryId = player.mediaEntry?.id {
+                  let entryId = player.mediaEntry?.id {
             
             updateEntryId(entryId)
         }
-                
+        
         if config.partnerId <= 0 {
             config.partnerId = KavaPluginConfig.defaultKavaPartnerId
             config.entryId = KavaPluginConfig.defaultKavaEntryId

--- a/Sources/KavaPlugin.swift
+++ b/Sources/KavaPlugin.swift
@@ -279,12 +279,11 @@ let playbackPoints: [KavaPlugin.EventType] = [KavaPlugin.EventType.playReached25
         }
     }
     
-    private func updateEntryId(_ entryId: String) {
-        if !entryId.isEmpty {
-            
+    private func update(entryId: String) {
+        // Testing if entryId is string mixing letters and numbers it is OVP id.
+        if !entryId.isEmpty, (Int(entryId) == nil) { // OVP
             config.entryId = entryId
         } else {
-            
             config.entryId = KavaPluginConfig.defaultKavaEntryId
             config.partnerId = KavaPluginConfig.defaultKavaPartnerId
         }
@@ -326,20 +325,17 @@ let playbackPoints: [KavaPlugin.EventType] = [KavaPlugin.EventType.playReached25
         self.kavaData.mediaCurrentTime = player.currentTime
         
         if let metadata = player.mediaEntry?.metadata,
-           let partnerId = Int(metadata["partnerId"] ?? "") {
+           let partnerId = Int(metadata["partnerId"] ?? "") { // For OVP
             config.partnerId = partnerId
         }
         
         if config.entryId == nil,
            let metadata = player.mediaEntry?.metadata,
-           let entryId = metadata["entryId"] {
-            
-            updateEntryId(entryId)
-            
+           let entryId = metadata["entryId"] { // For OTT or OVP
+            update(entryId: entryId)
         } else if config.entryId == nil,
-                  let entryId = player.mediaEntry?.id {
-            
-            updateEntryId(entryId)
+                  let entryId = player.mediaEntry?.id { // For OVP
+            update(entryId: entryId)
         }
         
         if config.partnerId <= 0 {

--- a/Sources/KavaPlugin.swift
+++ b/Sources/KavaPlugin.swift
@@ -279,6 +279,17 @@ let playbackPoints: [KavaPlugin.EventType] = [KavaPlugin.EventType.playReached25
         }
     }
     
+    private func updateEntryId(_ entryId: String) {
+        if !entryId.isEmpty {
+            
+            config.entryId = entryId
+        } else {
+            
+            config.entryId = KavaPluginConfig.defaultKavaEntryId
+            config.partnerId = KavaPluginConfig.defaultKavaPartnerId
+        }
+    }
+    
     func sendAnalyticsEvent(event: EventType) {
         guard let player = self.player else {
             PKLog.warning("Player/ MediaEntry is nil")
@@ -314,19 +325,23 @@ let playbackPoints: [KavaPlugin.EventType] = [KavaPlugin.EventType.playReached25
         self.kavaData.mediaDuration = player.duration
         self.kavaData.mediaCurrentTime = player.currentTime
         
-        if config.entryId == nil,
-           let entryId = player.mediaEntry?.id {
-            
-            config.entryId = entryId
-        } else if config.entryId == nil,
-                  let metadata = player.mediaEntry?.metadata,
-                  let partnerId = Int(metadata["partnerId"] ?? ""),
-                  let entryId = metadata["entryId"] {
-            
+        if let metadata = player.mediaEntry?.metadata,
+             let partnerId = Int(metadata["partnerId"] ?? "") {
             config.partnerId = partnerId
-            config.entryId = entryId
         }
         
+        if config.entryId == nil,
+                  let metadata = player.mediaEntry?.metadata,
+                  let entryId = metadata["entryId"] {
+            
+            updateEntryId(entryId)
+                  
+        } else if config.entryId == nil,
+           let entryId = player.mediaEntry?.id {
+            
+            updateEntryId(entryId)
+        }
+                
         if config.partnerId <= 0 {
             config.partnerId = KavaPluginConfig.defaultKavaPartnerId
             config.entryId = KavaPluginConfig.defaultKavaEntryId


### PR DESCRIPTION
Solves FEC-11651
update logic to populate entryId from metadata
update logic to set to default kava params

